### PR TITLE
Add ci

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-      - "add-ci"
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add github actions to build container and store in GHCR. Currently only builds on push to main branch. Container tag is date time. Previous build failed due to permissions I have on repo (I think)