### PR TITLE
Implement Watchdog & Permissions Checks

### DIFF
--- a/channel/FFMPEG.py
+++ b/channel/FFMPEG.py
@@ -102,13 +102,20 @@ class FFMPEG(channel):
                 f = os.path.join(path, file)
                 if os.path.isfile(f):
                     if self.isScannedFileVideo(file):
+                        if not os.access(f, os.R_OK):
+                            self.logger.warning("Do not have read permissions on file %s" % f)
+                            continue
                         scanValues.append(f)
                     else:
                         self.logger.warning("Unknown File Extension encountered %s/%s" % (path, file))
                 else:
                     for seasonFile in os.listdir(f):
                         if self.isScannedFileVideo(seasonFile):
-                            scanValues.append(os.path.join(f, seasonFile))
+                            seasonf = os.path.join(f, seasonFile)
+                            if not os.access(seasonf, os.R_OK):
+                                self.logger.warning("Do not have read permissions on file %s" % seasonf)
+                                continue
+                            scanValues.append(seasonf)
             if len(scanValues) != 0:
                 self.showPaths.append(scanValues)
         self.logger.debug(
@@ -130,6 +137,9 @@ class FFMPEG(channel):
             self.createEPGItems()
             return self.getShow()
         show = availShows.pop(0)
+        if not os.access(show.path, os.R_OK):
+            self.logger.error("Lost read permissions on file %s" % show.path)
+            return "assets/channelUnavailable.ts", datetime.now()
         self.logger.debug('Running show %s' % show.path)
         return show.path, show.startTime
 

--- a/channel/WatchDog.py
+++ b/channel/WatchDog.py
@@ -1,0 +1,45 @@
+import os
+import threading
+import time
+
+from watchdog.observers.polling import PollingObserver
+from watchdog.events import FileSystemEventHandler
+
+HandlerToObserver = {}
+class WatchDogObserver:
+    def __init__(self, baseDir, showDirs, channel):
+        self.observer = None
+        self.baseDir = baseDir
+        self.showDirs = showDirs
+        self.channel = channel
+        self._thread = threading.Thread(target=self.startObeserver, args=())
+        self._thread.start()
+
+    def rebootChannel(self):
+        self.channel.pendReboot()
+
+    def startObeserver(self):
+        self.observer = PollingObserver()
+        event_handler = WatchDogHandler()
+        HandlerToObserver[event_handler] = self
+        for show in self.showDirs:
+            watchDirectory = os.path.join(self.baseDir, show)
+            self.observer.schedule(event_handler, watchDirectory, recursive=True)
+        self.observer.start()
+
+
+class WatchDogHandler(FileSystemEventHandler):
+
+    def on_created(self, event):
+        if event.is_directory:
+            return None
+        time.sleep(10)
+        observer = HandlerToObserver[self]
+        observer.rebootChannel()
+
+    def on_deleted(self, event):
+        if event.is_directory:
+            return None
+        time.sleep(10)
+        observer = HandlerToObserver[self]
+        observer.rebootChannel()

--- a/channel/channel.py
+++ b/channel/channel.py
@@ -18,6 +18,7 @@ class channel:
         self._thread = None
         self.videoQuality = channelDef.get("videoQuality", dvrConfig["FFMPEG"]['videoQuality'])
         self.resolution = channelDef.get("resolution", [1280, 720])
+        self.pendingReboot = False
         with open("assets/channelUnavailable.ts", "rb") as blankTS:
             self.blankVideo = blankTS.read()
 

--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,4 @@ Server:
   url: http://127.0.0.1:5004 # URL used for lineup and epg
   gunicornThreads: 1 # Threads gunicorn uses to handle requests
   gunicornWorkers: 1 # Number of workers gunicorn is to spawn
+  useWatchdog: true # Whether to use WatchDog Polling for file system changes

--- a/createCache.py
+++ b/createCache.py
@@ -8,6 +8,8 @@ channelMap = {
 }
 
 channelID = 0
+# Sets useWatchdog to False, as we don't need it in cache generation
+dvrConfig["Server"]['useWatchdog'] = False
 
 # Defines and sets up FFMPEG channels
 for channelDef in dvrConfig.get("Channels", []):

--- a/main.py
+++ b/main.py
@@ -62,6 +62,8 @@ def epg():
 
 @app.route('/stream/<channel>')
 def stream(channel):
+    if channelMap[channel].pendingReboot:
+        return "Channel Rebooting", 500
     def generate(channel):
         buffer = channelMap[channel].createBuffer()
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ moviepy
 pyyaml
 gevent
 Gunicorn
+watchdog


### PR DESCRIPTION
This PR aims to resolve a couple issues with PyPlexDVR

1. If its loses read permissions on a file, the application does not handle it
2. The application must be restarted each time a new file is added

These issues are resolved by

- Adding permission checks in the scanShows function of FFMPEG.py
- Adding a permissions check to the getShow function of FFMPEG.py
    - When we don't have permissions, channelUnavailable.ts is played instead
- Implementing a WatchDog observer, which restarts Channels when there are no viewers and the filesystem has a change